### PR TITLE
UI streamlining and translation scanner optimization

### DIFF
--- a/src/Actions/SynchronizeAction.php
+++ b/src/Actions/SynchronizeAction.php
@@ -2,11 +2,12 @@
 
 namespace musa11971\FilamentTranslationManager\Actions;
 
-use Filament\Pages\Actions\Action;
 use Filament\Pages\Page;
-use musa11971\FilamentTranslationManager\Commands\SynchronizeTranslationsCommand;
-use musa11971\FilamentTranslationManager\Helpers\TranslationScanner;
+use Illuminate\Support\Str;
+use Filament\Pages\Actions\Action;
 use Spatie\TranslationLoader\LanguageLine;
+use musa11971\FilamentTranslationManager\Helpers\TranslationScanner;
+use musa11971\FilamentTranslationManager\Commands\SynchronizeTranslationsCommand;
 
 class SynchronizeAction extends Action
 {
@@ -22,45 +23,39 @@ class SynchronizeAction extends Action
      */
     public static function synchronize(SynchronizeTranslationsCommand $command = null): array
     {
-        $command?->loudInfo('synchronize function called');
+        // extract all translation groups, keys and text
+        $groupsAndKeys = TranslationScanner::scan();
 
         $result = [];
-
-        // Create non-existing groups and keys
-        $scanner = new TranslationScanner($command);
-        $groupsAndKeys = $scanner->start();
-
-        $result['total_count'] = count($groupsAndKeys);
+        $result['total_count'] = 0;
 
         // Find and delete old LanguageLines that no longer exist in the translation files
-        $result['deleted_count'] = LanguageLine::whereNotIn('group', array_column($groupsAndKeys, 'group'))
+        $result['deleted_count'] = LanguageLine::query()
+            ->whereNotIn('group', array_column($groupsAndKeys, 'group'))
             ->orWhereNotIn('key', array_column($groupsAndKeys, 'key'))
             ->delete();
 
-        $command?->loudInfo('deleted old languagelines');
-
-        $command?->loudInfo('found ' . $result['total_count'] . ' total language lines');
-        $command?->loudInfo('deleted ' . $result['deleted_count'] . ' unused ones');
-
         // Create new LanguageLines for the groups and keys that don't exist yet
         foreach ($groupsAndKeys as $groupAndKey) {
-            $command?->loudInfo('updateOrCreate: ' . $groupAndKey['group'] . '.' . $groupAndKey['group']);
+            $startTime = microtime(true);
 
             $existingItem = LanguageLine::where('group', $groupAndKey['group'])
                 ->where('key', $groupAndKey['key'])
                 ->first();
+
             if (!$existingItem) {
                 LanguageLine::create([
                     'group' => $groupAndKey['group'],
                     'key' => $groupAndKey['key'],
                     'text' => $groupAndKey['text'],
                 ]);
+
+                $result['total_count'] += 1;
+
+                $runTime = number_format((microtime(true) - $startTime) * 1000, 2);
+                $command?->components()->twoColumnDetail($groupAndKey['group'] . '.' . $groupAndKey['key'], "<fg=gray>$runTime ms</> <fg=green;options=bold>DONE</>");
             }
-
-            $command?->loudInfo('done');
         }
-
-        $command?->loudInfo('finished synchronize function');
 
         return $result;
     }

--- a/src/Actions/SynchronizeAction.php
+++ b/src/Actions/SynchronizeAction.php
@@ -41,7 +41,7 @@ class SynchronizeAction extends Action
 
             $existingItem = LanguageLine::where('group', $groupAndKey['group'])
                 ->where('key', $groupAndKey['key'])
-                ->exist();
+                ->first();
 
             if (!$existingItem) {
                 LanguageLine::create([

--- a/src/Commands/SynchronizeTranslationsCommand.php
+++ b/src/Commands/SynchronizeTranslationsCommand.php
@@ -21,34 +21,29 @@ class SynchronizeTranslationsCommand extends Command
      */
     protected $description = 'Synchronize all application translations';
 
+    public function components()
+    {
+        return $this->components;
+    }
+
     /**
      * Execute the console command.
      */
     public function handle(): void
     {
         $startTime = microtime(true);
-        $this->info('Synchronization busy...');
+        $this->components->info('Starting synchronization.');
 
         $result = SynchronizeAction::synchronize($this);
+        $this->newLine();
 
-        $elapsedSecs = round(microtime(true) - $startTime, 2);
-        $this->info('Synchronization success! (' . $elapsedSecs . 's)');
-        $this->loudInfo('  - total: ' . $result['total_count']);
-        $this->loudInfo('  - deleted: ' . $result['deleted_count']);
-    }
+        $this->components->bulletList([
+            'synced translations: ' . $result['total_count'],
+            'purged translations: ' . $result['deleted_count'],
+        ]);
+        $this->newLine();
 
-    /**
-     * Prints the info message if loud option is enabled.
-     *
-     * @return void
-     */
-    public function loudInfo($message)
-    {
-        if (! $this->option('loud')) {
-            return;
-        }
-
-        $prefix = '[' . now()->format('H:i:s') . '] ! ';
-        $this->info($prefix . $message);
+        $runTime = number_format((microtime(true) - $startTime) * 1000, 0);
+        $this->components->info('Synchronization success! (' . $runTime . 'ms)');
     }
 }

--- a/src/Helpers/TranslationScanner.php
+++ b/src/Helpers/TranslationScanner.php
@@ -2,107 +2,57 @@
 
 namespace musa11971\FilamentTranslationManager\Helpers;
 
-use Illuminate\Console\Command;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use musa11971\FilamentTranslationManager\Commands\SynchronizeTranslationsCommand;
+use Illuminate\Support\Facades\File;
 
 class TranslationScanner
 {
-    private ?Command $command;
-
-    public function __construct(SynchronizeTranslationsCommand $command = null)
-    {
-        $this->command = $command;
-    }
-
     /**
      * Starts the translation scanning process.
      *
      * @return array An array containing all translation groups and keys found in the application.
      */
-    public function start(): array
+    public static function scan(): array
     {
-        $this->command?->loudInfo('starting scanner');
-
-        $files = File::allFiles(lang_path());
-
-        $this->command?->loudInfo('found files count: ' . count($files));
-
         $allGroupsAndKeys = [];
-        $seenCombinations = [];
+        $files = File::allFiles(lang_path());
 
         // Loop through all groups
         foreach ($files as $file) {
-            $this->command?->loudInfo('looping for file ' . $file->getRelativePathname());
-
-            $name = $file->getRelativePathname();
-
-            // Remove the .php extension
-            $name = Str::replace('.php', '', $name);
-
             // Remove the first part (e.g. nl)
-            $nameParts = explode(DIRECTORY_SEPARATOR, $name);
+            $nameParts = explode(DIRECTORY_SEPARATOR, $file->getRelativePathname());
 
             // TODO: add support for vendor translations
             if ($nameParts[0] == 'vendor') {
-                $this->command?->loudInfo('skipped vendor: ' . $name);
-
                 continue;
             }
 
-            unset($nameParts[0]);
-            $name = implode(DIRECTORY_SEPARATOR, $nameParts);
+            // load the dat from the file
+            $data = require $file;
 
-            // Traverse the array keys in this group
-            $groupArray = trans($name, [], config('app.fallback_locale'));
+            foreach ($data as $key => $value) {
+                $found = false;
+                $group = Str::replace('.php', '', $nameParts[1]);
 
-            if (! is_array($groupArray)) {
-                $this->command?->loudInfo('skipped non-array: ' . $name);
-
-                continue;
-            }
-
-            $this->traverseArray($groupArray, $seenCombinations, $allGroupsAndKeys, $name);
-        }
-
-        $this->command?->loudInfo('scanner done');
-
-        return $allGroupsAndKeys;
-    }
-
-    /**
-     * Recursively traverses an array and adds all keys to the `$allGroupsAndKeys` array.
-     *
-     * @param  array  $array The array to traverse.
-     * @param  array  $allGroupsAndKeys The array to add the keys to.
-     * @param  string  $groupName The name of the translation group.
-     * @param  string|null  $parentKey The parent key path, if applicable.
-     */
-    private function traverseArray($array, &$seenCombinations, &$allGroupsAndKeys, $groupName, $parentKey = null): void
-    {
-        foreach ($array as $key => $value) {
-            $currentKey = $parentKey ? $parentKey . '.' . $key : $key;
-
-            if (is_array($value)) {
-                $this->traverseArray($value, $seenCombinations, $allGroupsAndKeys, $groupName, $currentKey);
-            } else {
-                // Skip if this group and key pair has already been added
-                if (isset($seenCombinations[$groupName][$currentKey])) {
-                    continue;
+                // check if the translation is already present and append it
+                foreach ($allGroupsAndKeys as &$GroupAndKey) {
+                    if ($GroupAndKey['group'] === $group && $GroupAndKey['key'] === $key) {
+                        $GroupAndKey['text'][$nameParts[0]] = $value;
+                        $found = true;
+                    }
                 }
 
-                // Add this group and key pair to the array
-                $seenCombinations[$groupName][$currentKey] = true;
-
-                $this->command?->loudInfo('added ' . $groupName . '.' . $currentKey);
-
-                $allGroupsAndKeys[] = [
-                    'group' => $groupName,
-                    'key' => $currentKey,
-                    'text' => [],
-                ];
+                // new translation found
+                if (!$found) {
+                    $allGroupsAndKeys[] = [
+                        'group' => $group,
+                        'key' => $key,
+                        'text' => [$nameParts[0] => $value],
+                    ];
+                }
             }
         }
+
+        return $allGroupsAndKeys;
     }
 }


### PR DESCRIPTION
This PR covers several updates:
1. The translation scanner process has been streamlined, so that the TranslationScanner now reads PHP files from the project directly and merges all discovered translations into $allGroupsAndKeys, which represents the LanguageLine table data in memory. Once this data is returned, any outdated translations are purged and the language lines are added to the table. Additionally, existing translations are now loaded into the database for improved efficiency.
2. The command-line user interface has been redesigned to match Laravel's modern look and feel. The amount of output has also been reduced to functional output only, improving the user experience.

![image](https://user-images.githubusercontent.com/865062/237044308-ebfa0f3a-3d5b-483d-992b-18cd6f4a66f1.png)
